### PR TITLE
Specify npm versions

### DIFF
--- a/packages/schematics/src/commitlint/index.spec.ts
+++ b/packages/schematics/src/commitlint/index.spec.ts
@@ -55,9 +55,9 @@ describe('@co-it/schematics:commitlint', () => {
       );
       expect(packageAfterInstall.devDependencies).toEqual(
         expect.objectContaining({
-          '@commitlint/cli': 'latest',
-          '@commitlint/config-conventional': 'latest',
-          husky: 'latest'
+          '@commitlint/cli': expect.anything(),
+          '@commitlint/config-conventional': expect.anything(),
+          husky: expect.anything()
         })
       );
     });

--- a/packages/schematics/src/commitlint/index.ts
+++ b/packages/schematics/src/commitlint/index.ts
@@ -14,9 +14,9 @@ export default function commitlint(): Rule {
   return chain([
     installDependencies({
       devDependencies: [
-        { name: '@commitlint/cli' },
-        { name: '@commitlint/config-conventional' },
-        { name: 'husky' }
+        { name: '@commitlint/cli', version: '^7.5.2' },
+        { name: '@commitlint/config-conventional', version: '^7.5.0 ' },
+        { name: 'husky', version: '^1.3.1' }
       ]
     }),
     warnAgainstCompetingConfiguration({

--- a/packages/schematics/src/jest/rules/jest/configure-jest.ts
+++ b/packages/schematics/src/jest/rules/jest/configure-jest.ts
@@ -26,9 +26,9 @@ export function configureJest(): Rule {
     chain([
       installDependencies({
         devDependencies: [
-          { name: 'jest' },
-          { name: 'jest-preset-angular' },
-          { name: '@types/jest' }
+          { name: 'jest', version: '^24.5.0' },
+          { name: 'jest-preset-angular', version: '^7.0.1' },
+          { name: '@types/jest', version: '^24.0.11' }
         ]
       }),
       removeDependencies({

--- a/packages/schematics/src/prettier/index.ts
+++ b/packages/schematics/src/prettier/index.ts
@@ -29,9 +29,9 @@ export function configureHusky(): Rule {
   return chain([
     installDependencies({
       devDependencies: [
-        { name: 'husky' },
-        { name: 'pretty-quick' },
-        { name: 'lint-staged' }
+        { name: 'husky', version: '^1.3.1' },
+        { name: 'pretty-quick', version: '^1.10.0' },
+        { name: 'lint-staged', version: '^8.1.5' }
       ]
     }),
     applyHuskyConfiguration([

--- a/packages/schematics/src/prettier/rules/prettier/configure-prettier.ts
+++ b/packages/schematics/src/prettier/rules/prettier/configure-prettier.ts
@@ -24,8 +24,8 @@ export function configurePrettier(): Rule {
     chain([
       installDependencies({
         devDependencies: [
-          { name: 'prettier' },
-          { name: 'tslint-config-prettier' }
+          { name: 'prettier', version: '^1.16.4' },
+          { name: 'tslint-config-prettier', version: '^1.18.0' }
         ]
       }),
       mergeWith(


### PR DESCRIPTION
Specifying a concrete version is safer since we hopefully avoid breaking changes caused by used packages.