### PR TITLE
Fix: Angular CLI 7.2.x schematic discovery

### DIFF
--- a/packages/schematics/src/collection.json
+++ b/packages/schematics/src/collection.json
@@ -8,7 +8,8 @@
     },
     "commitlint": {
       "description": "Install & configure commitlint",
-      "factory": "./commitlint/index"
+      "factory": "./commitlint/index",
+      "schema": "./commitlint/commitlint.schema.json"
     },
     "tsconfig": {
       "description": "refine tsconfig.json making it more strict",
@@ -17,7 +18,8 @@
     },
     "jest": {
       "description": "configure the angular project to test with jest",
-      "factory": "./jest/index"
+      "factory": "./jest/index",
+      "schema": "./jest/jest.schema.json"
     },
     "cypress": {
       "description": "Install & configure cypress",

--- a/packages/schematics/src/commitlint/commitlint.schema.json
+++ b/packages/schematics/src/commitlint/commitlint.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "properties": {}
+}

--- a/packages/schematics/src/jest/jest.schema.json
+++ b/packages/schematics/src/jest/jest.schema.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "properties": {}
+}


### PR DESCRIPTION
Angular CLI 7.2.1 needs a schema.json file for each schematic in order to execute them.

I added the schema files for jest and commitlint.
I already tested it with a project having Angular CLI 7.2.4 installed.