### PR TITLE
Fix/tslint

### DIFF
--- a/packages/schematics/src/prettier/rules/tslint/opinionated-tslint-rules.ts
+++ b/packages/schematics/src/prettier/rules/tslint/opinionated-tslint-rules.ts
@@ -1,8 +1,0 @@
-export const opinionatedTsLintRules = {
-  rules: {
-    quotemark: [true, 'single'],
-    'arrow-parens': false,
-    'max-line-length': [true, 80],
-    'trailing-comma': [true, { multiline: 'never', singleline: 'never' }]
-  }
-};

--- a/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.spec.ts
+++ b/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.spec.ts
@@ -29,35 +29,11 @@ describe('When "extends" does not exist', () => {
     expect(tslintJson.extends).toContain('tslint-config-prettier');
   });
 
-  it.skip('should enforce single quotes', () => {
-    rule(tree, emptyContext);
-
-    const tslintJson = JSON.parse(tree.readContent('tslint.json'));
-    expect(tslintJson.rules.quotemark).toEqual([true, 'single']);
-  });
-
   it('should remove max-line-length rule', () => {
     rule(tree, emptyContext);
 
     const tslintJson = JSON.parse(tree.readContent('tslint.json'));
     expect(tslintJson.rules['max-line-length']).toBeUndefined();
-  });
-
-  it.skip('should avoid arrow parens', () => {
-    rule(tree, emptyContext);
-
-    const tslintJson = JSON.parse(tree.readContent('tslint.json'));
-    expect(tslintJson.rules['arrow-parens']).toBe(false);
-  });
-
-  it.skip('should avoid trailing-comma', () => {
-    rule(tree, emptyContext);
-
-    const tslintJson = JSON.parse(tree.readContent('tslint.json'));
-    expect(tslintJson.rules['trailing-comma']).toEqual([
-      true,
-      { multiline: 'never', singleline: 'never' }
-    ]);
   });
 });
 

--- a/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.spec.ts
+++ b/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.spec.ts
@@ -35,6 +35,12 @@ describe('When "extends" does not exist', () => {
     const tslintJson = JSON.parse(tree.readContent('tslint.json'));
     expect(tslintJson.rules['max-line-length']).toBeUndefined();
   });
+
+  it('should not remove existing rules', () => {
+    rule(tree, emptyContext);
+    const tslintJson = JSON.parse(tree.readContent('tslint.json'));
+    expect(tslintJson.rules['array-type']).toBe(false);
+  });
 });
 
 describe('When no tslint.json is present', () => {

--- a/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.spec.ts
+++ b/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.spec.ts
@@ -11,7 +11,15 @@ describe('When "extends" does not exist', () => {
     rule = patchTsLintConfiguration();
     emptyContext = {} as SchematicContext;
     tree = new UnitTestTree(Tree.empty());
-    tree.create('tslint.json', JSON.stringify({}));
+    tree.create(
+      'tslint.json',
+      JSON.stringify({
+        rules: {
+          'max-line-length': [true, 140],
+          'array-type': false
+        }
+      })
+    );
   });
 
   it('should add the property and add prettier tslint configuration', () => {
@@ -21,28 +29,28 @@ describe('When "extends" does not exist', () => {
     expect(tslintJson.extends).toContain('tslint-config-prettier');
   });
 
-  it('should enforce single quotes', () => {
+  it.skip('should enforce single quotes', () => {
     rule(tree, emptyContext);
 
     const tslintJson = JSON.parse(tree.readContent('tslint.json'));
     expect(tslintJson.rules.quotemark).toEqual([true, 'single']);
   });
 
-  it('should enforce max line length 80', () => {
+  it('should remove max-line-length rule', () => {
     rule(tree, emptyContext);
 
     const tslintJson = JSON.parse(tree.readContent('tslint.json'));
-    expect(tslintJson.rules['max-line-length']).toEqual([true, 80]);
+    expect(tslintJson.rules['max-line-length']).toBeUndefined();
   });
 
-  it('should avoid arrow parens', () => {
+  it.skip('should avoid arrow parens', () => {
     rule(tree, emptyContext);
 
     const tslintJson = JSON.parse(tree.readContent('tslint.json'));
     expect(tslintJson.rules['arrow-parens']).toBe(false);
   });
 
-  it('should avoid trailing-comma', () => {
+  it.skip('should avoid trailing-comma', () => {
     rule(tree, emptyContext);
 
     const tslintJson = JSON.parse(tree.readContent('tslint.json'));

--- a/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.ts
+++ b/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.ts
@@ -21,8 +21,17 @@ export function patchTsLintConfiguration(): Rule {
       originTsLintJson.extends = ['tslint-config-prettier'];
     }
 
-    const tslintJson = { ...originTsLintJson, ...opinionatedTsLintRules };
+    let tslintJson = { ...originTsLintJson, ...opinionatedTsLintRules };
+    tslintJson = omitRule(tslintJson, 'max-line-length');
 
     tree.overwrite('tslint.json', JSON.stringify(tslintJson, null, 2));
   };
+}
+
+function omitRule(
+  tslintConfig: { rules: { [key: string]: any } },
+  ruleKey: string
+): object {
+  delete tslintConfig.rules[ruleKey];
+  return tslintConfig;
 }

--- a/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.ts
+++ b/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.ts
@@ -1,5 +1,4 @@
 import { Rule, Tree } from '@angular-devkit/schematics';
-import { opinionatedTsLintRules } from './opinionated-tslint-rules';
 
 export function patchTsLintConfiguration(): Rule {
   return (tree: Tree) => {
@@ -28,9 +27,13 @@ export function patchTsLintConfiguration(): Rule {
 }
 
 function omitRule(
-  tslintConfig: { rules: { [key: string]: any } },
+  tslintConfig: { rules?: { [key: string]: any } },
   ruleKey: string
 ): object {
+  if (!tslintConfig || !tslintConfig.rules) {
+    return tslintConfig;
+  }
+
   delete tslintConfig.rules[ruleKey];
   return tslintConfig;
 }

--- a/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.ts
+++ b/packages/schematics/src/prettier/rules/tslint/patch-ts-lint-configuration.ts
@@ -21,8 +21,7 @@ export function patchTsLintConfiguration(): Rule {
       originTsLintJson.extends = ['tslint-config-prettier'];
     }
 
-    let tslintJson = { ...originTsLintJson, ...opinionatedTsLintRules };
-    tslintJson = omitRule(tslintJson, 'max-line-length');
+    const tslintJson = omitRule(originTsLintJson, 'max-line-length');
 
     tree.overwrite('tslint.json', JSON.stringify(tslintJson, null, 2));
   };


### PR DESCRIPTION
I changed a few things regarding tslint.

- We do not introduce our own rules since the current tslint.json provided by Angular CLI matches our settings
- `max-line-length` rule is removed (avoids possible conflicts with prettier)
- _FIX_ We do not overwrite the whole rules object anymore which accidentally removed existing tslint rules